### PR TITLE
Changed Display to use States

### DIFF
--- a/MediaManagementSystem/MediaManagementSystem.iml
+++ b/MediaManagementSystem/MediaManagementSystem.iml
@@ -1,14 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
-  <component name="FacetManager">
-    <facet type="web" name="Web">
-      <configuration>
-        <webroots>
-          <root url="file://$MODULE_DIR$/src/main/webapp" relative="/" />
-        </webroots>
-      </configuration>
-    </facet>
-  </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/controller/MainController.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/controller/MainController.java
@@ -6,6 +6,7 @@ import com.csci4448.MediaManagementSystem.ui.*;
 public class MainController {
 
     private Display display;
+    private User activeUser;
 
     public MainController() {
         display = new Display(this);
@@ -25,7 +26,8 @@ public class MainController {
         //ToDo: check if valid input, if not inform display
         display.removeLogin();
         //ToDo: add user from login, not a new user
-        display.initializeMainLayout(new User());
+        activeUser = new User();
+        display.initializeMainLayout();
         display.displayStore();
     }
 
@@ -42,7 +44,8 @@ public class MainController {
     public void createAccountSubmitRequest(String firstName, String lastName, String username, String email, String password) {
         //ToDo: check if valid input, if not inform display
         display.removeCreateAccount();
-        display.initializeMainLayout(new User());
+        activeUser = new User();
+        display.initializeMainLayout();
     }
 
     public void storeRequest() {
@@ -56,4 +59,8 @@ public class MainController {
     public void addFundsRequest() {
 
     }
+
+    public User getUser() { return activeUser; }
+    public void setUser(User user) { activeUser = user; }
+    public boolean hasUser() { return activeUser != null; }
 }

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/controller/MainController.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/controller/MainController.java
@@ -1,6 +1,7 @@
 package com.csci4448.MediaManagementSystem.controller;
 
 import com.csci4448.MediaManagementSystem.model.*;
+import com.csci4448.MediaManagementSystem.state.*;
 import com.csci4448.MediaManagementSystem.ui.*;
 
 public class MainController {
@@ -10,49 +11,46 @@ public class MainController {
 
     public MainController() {
         display = new Display(this);
-        display.displayLogin();
+        display.setState(new LoginState());
     }
 
     public static void main(String[] args) {
         MainController c = new MainController();
-
-    }
-
-    public void loginRequest() {
-        display.displayLogin();
     }
 
     public void loginSubmitRequest(String username, String password) {
         //ToDo: check if valid input, if not inform display
-        display.removeLogin();
+        //display.removeLogin();
         //ToDo: add user from login, not a new user
-        activeUser = new User();
-        display.initializeMainLayout();
-        display.displayStore();
+        //activeUser = new User();
+        //display.initializeMainLayout();
+        //storeRequest();
     }
 
     public void createAccountRequest() {
-        display.removeLogin();
-        display.displayCreateAccount();
+        display.setState(new CreateAccountState());
     }
 
     public void createAccountCancelRequest() {
-        display.removeCreateAccount();
-        display.displayLogin();
+        display.setState(new LoginState());
     }
 
     public void createAccountSubmitRequest(String firstName, String lastName, String username, String email, String password) {
         //ToDo: check if valid input, if not inform display
-        display.removeCreateAccount();
-        activeUser = new User();
-        display.initializeMainLayout();
+        //display.removeCreateAccount();
+        //activeUser = new User();
+        //display.initializeMainLayout();
     }
 
     public void storeRequest() {
-
+        //display.displayStore();
     }
 
     public void libraryRequest() {
+
+    }
+
+    public void adminRequest() {
 
     }
 

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/controller/MainController.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/controller/MainController.java
@@ -25,6 +25,11 @@ public class MainController {
         //activeUser = new User();
         //display.initializeMainLayout();
         //storeRequest();
+
+        // TODO: Properly set the user and whatnot, for now this generic user will work
+        activeUser = new User();
+
+        storeRequest();
     }
 
     public void createAccountRequest() {
@@ -40,10 +45,15 @@ public class MainController {
         //display.removeCreateAccount();
         //activeUser = new User();
         //display.initializeMainLayout();
+
+        // TODO: Properly set the user and whatnot, for now this generic user will work
+        activeUser = new User();
+
+        storeRequest();
     }
 
     public void storeRequest() {
-        //display.displayStore();
+        display.setState(new StoreState());
     }
 
     public void libraryRequest() {

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/model/User.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/model/User.java
@@ -22,7 +22,14 @@ public class User {
     private String lastName;
     private Boolean isAdmin;
 
-    public User() {}
+    public User() {
+        username = "";
+        password = "";
+        email = "";
+        firstName = "";
+        lastName = "";
+        isAdmin = new Boolean(true); // TODO: For now, all users are admins until we get the database up, for testing
+    }
 
     public int getId() {
         return id;

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/CreateAccountState.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/CreateAccountState.java
@@ -8,13 +8,12 @@ public class CreateAccountState implements DisplayState {
 
     private CreateAccountPanel createAccountPanel;
 
-    public CreateAccountState()
-    {
+    public CreateAccountState() {
         this.createAccountPanel = null;
     }
 
-    public void onActivate(MainController controller, Display display)
-    {
+    public void onActivate(MainController controller, Display display) {
+        display.invalidateMainLayout();
         display.setSize(350, 500);
         display.setResizable(false);
         display.setLocationRelativeTo(null);
@@ -25,8 +24,7 @@ public class CreateAccountState implements DisplayState {
         display.setVisible(true);
     }
 
-    public void onDeactivate(MainController controller, Display display)
-    {
+    public void onDeactivate(MainController controller, Display display) {
         display.remove(createAccountPanel);
     }
 

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/CreateAccountState.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/CreateAccountState.java
@@ -1,0 +1,34 @@
+package com.csci4448.MediaManagementSystem.state;
+
+import com.csci4448.MediaManagementSystem.controller.MainController;
+import com.csci4448.MediaManagementSystem.ui.CreateAccountPanel;
+import com.csci4448.MediaManagementSystem.ui.Display;
+
+public class CreateAccountState implements DisplayState {
+
+    private CreateAccountPanel createAccountPanel;
+
+    public CreateAccountState()
+    {
+        this.createAccountPanel = null;
+    }
+
+    public void onActivate(MainController controller, Display display)
+    {
+        display.setSize(350, 500);
+        display.setResizable(false);
+        display.setLocationRelativeTo(null);
+
+        createAccountPanel = new CreateAccountPanel(controller);
+        display.add(createAccountPanel);
+
+        display.setVisible(true);
+    }
+
+    public void onDeactivate(MainController controller, Display display)
+    {
+        display.remove(createAccountPanel);
+    }
+
+    public CreateAccountPanel getCreateAccountPanel() { return createAccountPanel; }
+}

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/DisplayState.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/DisplayState.java
@@ -1,0 +1,12 @@
+package com.csci4448.MediaManagementSystem.state;
+
+import com.csci4448.MediaManagementSystem.controller.MainController;
+import com.csci4448.MediaManagementSystem.ui.Display;
+
+public interface DisplayState {
+    // Called when the state is set as the active state
+    void onActivate(MainController controller, Display display);
+
+    // Called when the state is no longer the active state
+    void onDeactivate(MainController controller, Display display);
+}

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/LoginState.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/LoginState.java
@@ -1,0 +1,34 @@
+package com.csci4448.MediaManagementSystem.state;
+
+import com.csci4448.MediaManagementSystem.controller.MainController;
+import com.csci4448.MediaManagementSystem.ui.Display;
+import com.csci4448.MediaManagementSystem.ui.LoginPanel;
+
+public class LoginState implements DisplayState {
+
+    private LoginPanel loginPanel;
+
+    public LoginState()
+    {
+        this.loginPanel = null;
+    }
+
+    public void onActivate(MainController controller, Display display)
+    {
+        display.setSize(350, 300);
+        display.setResizable(false);
+        display.setLocationRelativeTo(null);
+
+        loginPanel = new LoginPanel(controller);
+        display.add(loginPanel);
+
+        display.setVisible(true);
+    }
+
+    public void onDeactivate(MainController controller, Display display)
+    {
+        display.remove(loginPanel);
+    }
+
+    public LoginPanel getLoginPanel() { return loginPanel; }
+}

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/LoginState.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/LoginState.java
@@ -8,13 +8,12 @@ public class LoginState implements DisplayState {
 
     private LoginPanel loginPanel;
 
-    public LoginState()
-    {
+    public LoginState() {
         this.loginPanel = null;
     }
 
-    public void onActivate(MainController controller, Display display)
-    {
+    public void onActivate(MainController controller, Display display) {
+        display.invalidateMainLayout();
         display.setSize(350, 300);
         display.setResizable(false);
         display.setLocationRelativeTo(null);
@@ -25,8 +24,7 @@ public class LoginState implements DisplayState {
         display.setVisible(true);
     }
 
-    public void onDeactivate(MainController controller, Display display)
-    {
+    public void onDeactivate(MainController controller, Display display) {
         display.remove(loginPanel);
     }
 

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/StoreState.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/StoreState.java
@@ -1,0 +1,20 @@
+package com.csci4448.MediaManagementSystem.state;
+
+import com.csci4448.MediaManagementSystem.controller.MainController;
+import com.csci4448.MediaManagementSystem.ui.Display;
+
+public class StoreState implements DisplayState {
+
+
+    public StoreState() {
+
+    }
+
+    public void onActivate(MainController controller, Display display) {
+        display.ensureMainLayout();
+    }
+
+    public void onDeactivate(MainController controller, Display display) {
+
+    }
+}

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/StoreState.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/state/StoreState.java
@@ -2,19 +2,39 @@ package com.csci4448.MediaManagementSystem.state;
 
 import com.csci4448.MediaManagementSystem.controller.MainController;
 import com.csci4448.MediaManagementSystem.ui.Display;
+import com.csci4448.MediaManagementSystem.ui.GridMediaPanel;
+import com.csci4448.MediaManagementSystem.ui.MediaListing;
+
+import javax.swing.*;
+import java.awt.*;
 
 public class StoreState implements DisplayState {
 
+    // Suggestion: don't store this here, a singleton or other controller for the store contents would be much better
+    GridMediaPanel mediaPanel;
 
     public StoreState() {
-
+        this.mediaPanel = null;
     }
 
     public void onActivate(MainController controller, Display display) {
         display.ensureMainLayout();
+
+        JPanel mainPanel = display.getMainWindowContent();
+
+        mediaPanel = new GridMediaPanel(controller, 215, 250, 15, 35);
+        mediaPanel.setLocation(15, 10);
+        for(int i = 0; i < 100; i++) {
+            mediaPanel.addMediaListing(new MediaListing());
+        }
+
+        mainPanel.add(mediaPanel);
+        mainPanel.setPreferredSize(new Dimension(935, mediaPanel.getHeight()));
     }
 
     public void onDeactivate(MainController controller, Display display) {
-
+        display.getMainWindowContent().remove(mediaPanel);
     }
+
+    public GridMediaPanel getMediaPanel() { return mediaPanel; }
 }

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/Display.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/Display.java
@@ -39,17 +39,12 @@ public class Display extends JFrame {
             activeState.onActivate(controller, this);
     }
 
-    // Adds a Component to the scrollLayout, assuming that it is currently the main layout
-    // If it is not currently in the main layout, it will add the component, but will not show the change.
-    public void addMainWindowContent(Component component) {
-        scrollLayout.add(component);
-    }
+    public DisplayState getActiveState() { return activeState; }
 
-    // Removes a Component from the scrollLayout, assuming that it is currently the main layout
-    // If it is not currently in the main layout, it will remove the component, but will not show the change.
-    public void removeMainWindowContent(Component component) {
-        scrollLayout.remove(component);
-    }
+    // Gets the scrollLayout that represents the main content when the window is in the main layout.
+    // DisplayStates that only change the content of the main window, and not the overall window itself (like LoginState
+    // and CreateAccountState do), should use this function to change the main window contents.
+    public JPanel getMainWindowContent() { return scrollLayout; }
 
     // Called by the states when they change the overall layout of the window from what is considered the "main layout".
     // This relies on the states to call this when needed, which opens it up to bugs, but should work for now.
@@ -106,21 +101,4 @@ public class Display extends JFrame {
         setVisible(true);
         isMainLayoutValid = true;
     }
-
-    //public void displayStore(/*ArrayList<Media>*/) {
-    //    GridMediaPanel g = new GridMediaPanel(controller, 215, 250, 15, 35);
-    //    scrollLayout.add(g);
-    //    g.setLocation(15, 10);
-    //    for(int i = 0; i < 100; i++) {
-    //        g.addMediaListing(new MediaListing());
-    //    }
-    //    scrollLayout.setPreferredSize(new Dimension(935, g.getHeight()));
-    //    //scrollLayout.invalidate();
-    //    //scrollView.repaint();
-    //
-    //}
-
-    //public void displayLibrary(/*ArrayList<Media>*/) {
-    //
-    //}
 }

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/Display.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/Display.java
@@ -2,6 +2,7 @@ package com.csci4448.MediaManagementSystem.ui;
 
 import com.csci4448.MediaManagementSystem.controller.*;
 import com.csci4448.MediaManagementSystem.model.*;
+import com.csci4448.MediaManagementSystem.state.*;
 
 import java.awt.*;
 import java.awt.event.ComponentAdapter;
@@ -17,15 +18,24 @@ public class Display extends JFrame {
     private JScrollPane scrollView;
     private JPanel scrollLayout;
     private MenuPanel menuPanel;
-    private boolean adminEditMode;
 
-    private LoginPanel loginPanel;
-    private CreateAccountPanel createAccountPanel;
+    private DisplayState activeState;
 
     public Display(MainController controller) {
         super("Media");
         this.controller = controller;
+        this.activeState = null;
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    }
+
+    public void setState(DisplayState state)
+    {
+        if (activeState != null)
+            activeState.onDeactivate(controller, this);
+
+        activeState = state;
+        if (activeState != null)
+            activeState.onActivate(controller, this);
     }
 
     public void initializeMainLayout() {
@@ -69,36 +79,6 @@ public class Display extends JFrame {
 
         add(mainLayout);
         setVisible(true);
-    }
-
-    public void displayLogin() {
-        setSize(350, 300);
-        setResizable(false);
-        setLocationRelativeTo(null);
-
-        loginPanel = new LoginPanel(controller);
-        add(loginPanel);
-
-        setVisible(true);
-    }
-
-    public void removeLogin() {
-        remove(loginPanel);
-    }
-
-    public void displayCreateAccount() {
-        setSize(350, 500);
-        setResizable(false);
-        setLocationRelativeTo(null);
-
-        createAccountPanel = new CreateAccountPanel(controller);
-        add(createAccountPanel);
-
-        setVisible(true);
-    }
-
-    public void removeCreateAccount() {
-        remove(createAccountPanel);
     }
 
     public void displayStore(/*ArrayList<Media>*/) {

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/Display.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/Display.java
@@ -28,7 +28,7 @@ public class Display extends JFrame {
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     }
 
-    public void initializeMainLayout(User user) {
+    public void initializeMainLayout() {
         setSize(950, 650);
         setMinimumSize(new Dimension(950, 425));
         setResizable(true);

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/Display.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/Display.java
@@ -20,16 +20,17 @@ public class Display extends JFrame {
     private MenuPanel menuPanel;
 
     private DisplayState activeState;
+    private boolean isMainLayoutValid;
 
     public Display(MainController controller) {
         super("Media");
         this.controller = controller;
         this.activeState = null;
+        this.isMainLayoutValid = false;
         setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
     }
 
-    public void setState(DisplayState state)
-    {
+    public void setState(DisplayState state) {
         if (activeState != null)
             activeState.onDeactivate(controller, this);
 
@@ -38,7 +39,31 @@ public class Display extends JFrame {
             activeState.onActivate(controller, this);
     }
 
-    public void initializeMainLayout() {
+    // Adds a Component to the scrollLayout, assuming that it is currently the main layout
+    // If it is not currently in the main layout, it will add the component, but will not show the change.
+    public void addMainWindowContent(Component component) {
+        scrollLayout.add(component);
+    }
+
+    // Removes a Component from the scrollLayout, assuming that it is currently the main layout
+    // If it is not currently in the main layout, it will remove the component, but will not show the change.
+    public void removeMainWindowContent(Component component) {
+        scrollLayout.remove(component);
+    }
+
+    // Called by the states when they change the overall layout of the window from what is considered the "main layout".
+    // This relies on the states to call this when needed, which opens it up to bugs, but should work for now.
+    public void invalidateMainLayout() {
+        if (isMainLayoutValid)
+            remove(mainLayout);
+
+        isMainLayoutValid = false;
+    }
+
+    public void ensureMainLayout() {
+        if (isMainLayoutValid)
+            return;
+
         setSize(950, 650);
         setMinimumSize(new Dimension(950, 425));
         setResizable(true);
@@ -79,23 +104,23 @@ public class Display extends JFrame {
 
         add(mainLayout);
         setVisible(true);
+        isMainLayoutValid = true;
     }
 
-    public void displayStore(/*ArrayList<Media>*/) {
-        GridMediaPanel g = new GridMediaPanel(controller, 215, 250, 15, 35);
-        scrollLayout.add(g);
-        g.setLocation(15, 10);
-        for(int i = 0; i < 100; i++) {
-            g.addMediaListing(new MediaListing());
-        }
-        scrollLayout.setPreferredSize(new Dimension(935, g.getHeight()));
-        //scrollLayout.invalidate();
-        //scrollView.repaint();
+    //public void displayStore(/*ArrayList<Media>*/) {
+    //    GridMediaPanel g = new GridMediaPanel(controller, 215, 250, 15, 35);
+    //    scrollLayout.add(g);
+    //    g.setLocation(15, 10);
+    //    for(int i = 0; i < 100; i++) {
+    //        g.addMediaListing(new MediaListing());
+    //    }
+    //    scrollLayout.setPreferredSize(new Dimension(935, g.getHeight()));
+    //    //scrollLayout.invalidate();
+    //    //scrollView.repaint();
+    //
+    //}
 
-    }
-
-    public void displayLibrary(/*ArrayList<Media>*/) {
-
-    }
-
+    //public void displayLibrary(/*ArrayList<Media>*/) {
+    //
+    //}
 }

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/MenuPanel.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/MenuPanel.java
@@ -13,6 +13,7 @@ public class MenuPanel extends JPanel implements ActionListener {
 
     private TextButton storeButton;
     private TextButton libraryButton;
+    private TextButton adminButton;
     private SearchBar searchBar;
     private TextButton fundsButton;
     private TextButton accountButton;
@@ -44,6 +45,13 @@ public class MenuPanel extends JPanel implements ActionListener {
         libraryButton.setSize(size);
         libraryButton.setLocation(180, (55-(int)size.getHeight())/2);
         add(libraryButton);
+
+        adminButton = new TextButton(this, "Admin", mainButtonFont, defaultColor, enteredColor, selectedColor);
+        size = adminButton.getPreferredSize();
+        adminButton.setSize(size);
+        adminButton.setLocation(290, (55-(int)size.getHeight())/2);
+        if (controller.getUser().getIsAdmin())
+            add(adminButton);
 
         accountButton = new TextButton(this, "Account", subButtonFont, defaultColor, enteredColor, selectedColor);
         size = accountButton.getPreferredSize();

--- a/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/MenuPanel.java
+++ b/MediaManagementSystem/src/main/java/com/csci4448/MediaManagementSystem/ui/MenuPanel.java
@@ -101,11 +101,18 @@ public class MenuPanel extends JPanel implements ActionListener {
         if (component.equals(storeButton)) {
             storeButton.setIsSelected(true);
             libraryButton.setIsSelected(false);
+            adminButton.setIsSelected(false);
             controller.storeRequest();
         } else if (component.equals(libraryButton)) {
             storeButton.setIsSelected(false);
             libraryButton.setIsSelected(true);
+            adminButton.setIsSelected(false);
             controller.libraryRequest();
+        } else if (component.equals(adminButton)) {
+            storeButton.setIsSelected(false);
+            libraryButton.setIsSelected(false);
+            adminButton.setIsSelected(true);
+            controller.adminRequest();
         } else if (component.equals(fundsButton)) {
             controller.addFundsRequest();
         } else if (component.equals(accountButton)) {


### PR DESCRIPTION
Added a new package called `state`, with the interface `DisplayState` and some of the initial implementations of the states. The `Display` class uses these states to properly change its interface when moving around between the different valid layouts. There are a few minor issues and weak points that could end up causing problems later (see: `Display.invalidateMainLayout()`), but nothing major.
